### PR TITLE
security: pin GitHub Actions to SHAs + Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 7
 


### PR DESCRIPTION
## Supply-chain hardening

This PR mirrors hardening applied to a sibling repo.

### Changes
- **Dependabot cooldown**: Added a \`cooldown\` block to the \`bun\` ecosystem entry in \`.github/dependabot.yml\` to delay newly released versions before opening update PRs (reduces exposure to compromised releases):
  - default-days: 7
  - semver-major-days: 30
  - semver-minor-days: 7
  - semver-patch-days: 7

### Not applicable
- **SHA-pinning GitHub Actions**: No \`.github/workflows/\` directory exists, so there are no \`uses:\` references to pin.
- **Dependabot Actions PRs**: No open Dependabot github-actions PRs to fold in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)